### PR TITLE
Fixed basename -s error when no remote.url is set

### DIFF
--- a/extend-history.plugin.zsh
+++ b/extend-history.plugin.zsh
@@ -29,7 +29,7 @@ _commit() {
 
 _record_project_info() {
   if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == true ]]; then
-    _record "git_branch=$(git rev-parse --abbrev-ref HEAD);git_commit=$(git rev-parse --short HEAD);git_project=$(basename -s .git `git config --get remote.origin.url`)"
+        _record "git_branch=$(git rev-parse --abbrev-ref HEAD);git_commit=$(git rev-parse --short HEAD);git_project=$(basename -s .git "$(git config --get remote.origin.url)")"
   fi
 
   # TODO support other language than Python

--- a/extend-history.plugin.zsh
+++ b/extend-history.plugin.zsh
@@ -29,7 +29,7 @@ _commit() {
 
 _record_project_info() {
   if [[ $(git rev-parse --is-inside-work-tree 2> /dev/null) == true ]]; then
-        _record "git_branch=$(git rev-parse --abbrev-ref HEAD);git_commit=$(git rev-parse --short HEAD);git_project=$(basename -s .git "$(git config --get remote.origin.url)")"
+    _record "git_branch=$(git rev-parse --abbrev-ref HEAD);git_commit=$(git rev-parse --short HEAD);git_project=$(basename -s .git "$(git config --get remote.origin.url)")"
   fi
 
   # TODO support other language than Python


### PR DESCRIPTION
![image](https://github.com/xav-b/zsh-extend-history/assets/6186996/b208354a-9180-4ea9-baf1-dfc35985fa56)

Steps to reproduce:

- Be inside a git repository
- mkdir subrepo
- cd subrepo
- git init && git commit
- pwd
--> it show basename -s error every command


i've added quote around git get remote so that's it default to empty string and basename won't fail